### PR TITLE
Fix MCP protocol compliance and improve Laravel 11+ setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ composer require chaoticingenuity/laravel-mcp-server
 php artisan vendor:publish --tag=mcp-config
 ```
 
-### 2. Publish Controllers and Middleware
+### 2. Publish Controllers (Optional)
 
 ```bash
 php artisan vendor:publish --tag=mcp-controllers
 ```
+
+**Note**: You only need to publish if you want to customize the MCPController. The middleware classes are used directly from the package namespace.
 
 ### 3. Laravel Version-Specific Setup
 
@@ -69,10 +71,10 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware) {
         // Register MCP middleware aliases
         $middleware->alias([
-            'mcp.auth' => \App\Http\Middleware\MCPAuthMiddleware::class,
-            'mcp.logging' => \App\Http\Middleware\MCPLoggingMiddleware::class,
-            'mcp.security' => \App\Http\Middleware\MCPSecurityMiddleware::class,
-            'mcp.throttle' => \App\Http\Middleware\MCPThrottleMiddleware::class,
+            'mcp.auth' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPAuthMiddleware::class,
+            'mcp.logging' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPLoggingMiddleware::class,
+            'mcp.security' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPSecurityMiddleware::class,
+            'mcp.throttle' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPThrottleMiddleware::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/README.md
+++ b/README.md
@@ -52,11 +52,12 @@ php artisan vendor:publish --tag=mcp-controllers
 
 #### Laravel 11+ (including Laravel 12) Setup (Recommended Method)
 
-For Laravel 11+, manually register middleware in `bootstrap/app.php`:
+For Laravel 11+, use the static helper method to register middleware in `bootstrap/app.php`:
 
 ```php
 <?php
 
+use ChaoticIngenuity\LaravelMCP\Providers\MCPServiceProvider;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -69,13 +70,8 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        // Register MCP middleware aliases
-        $middleware->alias([
-            'mcp.auth' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPAuthMiddleware::class,
-            'mcp.logging' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPLoggingMiddleware::class,
-            'mcp.security' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPSecurityMiddleware::class,
-            'mcp.throttle' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPThrottleMiddleware::class,
-        ]);
+        // Register MCP middleware aliases using static helper
+        $middleware->alias(MCPServiceProvider::middlewareAliases());
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -354,10 +354,10 @@ Make sure you've registered middleware aliases in `bootstrap/app.php`:
 
 ```php
 $middleware->alias([
-    'mcp.auth' => \App\Http\Middleware\MCPAuthMiddleware::class,
-    'mcp.logging' => \App\Http\Middleware\MCPLoggingMiddleware::class,
-    'mcp.security' => \App\Http\Middleware\MCPSecurityMiddleware::class,
-    'mcp.throttle' => \App\Http\Middleware\MCPThrottleMiddleware::class,
+    'mcp.auth' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPAuthMiddleware::class,
+    'mcp.logging' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPLoggingMiddleware::class,
+    'mcp.security' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPSecurityMiddleware::class,
+    'mcp.throttle' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPThrottleMiddleware::class,
 ]);
 ```
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,3 +6,7 @@ use Illuminate\Support\Facades\Route;
 Route::post('/mcp', [MCPController::class, 'handle'])
     ->middleware(['mcp.security', 'mcp.auth', 'mcp.throttle', 'mcp.logging'])
     ->name('mcp.handle');
+
+// Handle non-POST requests gracefully
+Route::match(['GET', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'], '/mcp', [MCPController::class, 'handleInvalidMethod'])
+    ->name('mcp.invalid_method');

--- a/src/Http/Controllers/MCPController.php
+++ b/src/Http/Controllers/MCPController.php
@@ -31,4 +31,20 @@ class MCPController extends Controller
             ], 500);
         }
     }
+
+    public function handleInvalidMethod(Request $request): JsonResponse
+    {
+        return response()->json([
+            'jsonrpc' => '2.0',
+            'error' => [
+                'code' => -32600,
+                'message' => 'Invalid Request - Only POST method allowed for MCP endpoints',
+                'data' => [
+                    'method' => $request->method(),
+                    'allowed_methods' => ['POST']
+                ]
+            ],
+            'id' => $request->input('id', null)
+        ], 405)->header('Allow', 'POST');
+    }
 }

--- a/src/Http/Middleware/MCPLoggingMiddleware.php
+++ b/src/Http/Middleware/MCPLoggingMiddleware.php
@@ -12,9 +12,11 @@ class MCPLoggingMiddleware
     {
         $startTime = microtime(true);
 
+        $logChannel = $this->getLogChannel();
+
         // Log incoming request if debug enabled
         if (config('mcp.debug.log_all_requests', false)) {
-            Log::channel('mcp')->info('MCP Request Started', [
+            $logChannel->info('MCP Request Started', [
                 'client' => $request->input('mcp_client', 'unknown'),
                 'method' => $request->input('method'),
                 'tool' => $request->input('params.name'),
@@ -28,7 +30,7 @@ class MCPLoggingMiddleware
         $duration = round((microtime(true) - $startTime) * 1000, 2);
 
         // Always log completed requests
-        Log::channel('mcp')->info('MCP Request', [
+        $logChannel->info('MCP Request', [
             'client' => $request->input('mcp_client', 'unknown'),
             'method' => $request->input('method'),
             'tool' => $request->input('params.name'),
@@ -39,5 +41,25 @@ class MCPLoggingMiddleware
         ]);
 
         return $response;
+    }
+
+    /**
+     * Get log channel, falling back to default if 'mcp' channel not configured
+     */
+    private function getLogChannel()
+    {
+        try {
+            $channelName = config('mcp.logging.channel', 'mcp');
+
+            // Check if channel exists in logging config
+            if (config("logging.channels.{$channelName}")) {
+                return Log::channel($channelName);
+            }
+        } catch (\Exception $e) {
+            // Silently fall back to default
+        }
+
+        // Fall back to default channel
+        return Log::channel(config('logging.default', 'stack'));
     }
 }

--- a/src/MCPServer.php
+++ b/src/MCPServer.php
@@ -41,7 +41,7 @@ class MCPServer
             'result' => [
                 'protocolVersion' => '2024-11-05',
                 'capabilities' => [
-                    'tools' => [],
+                    'tools' => new \stdClass(),
                     'resources' => [
                         'subscribe' => false,
                         'listChanged' => false,

--- a/src/Providers/MCPServiceProvider.php
+++ b/src/Providers/MCPServiceProvider.php
@@ -175,4 +175,27 @@ class MCPServiceProvider extends ServiceProvider
         }
         // Laravel 11+ users need to manually register in bootstrap/app.php
     }
+
+    /**
+     * Get middleware aliases for manual registration in Laravel 11+
+     *
+     * Usage in bootstrap/app.php:
+     *
+     * use ChaoticIngenuity\LaravelMCP\Providers\MCPServiceProvider;
+     *
+     * ->withMiddleware(function (Middleware $middleware) {
+     *     $middleware->alias(MCPServiceProvider::middlewareAliases());
+     * })
+     *
+     * @return array<string, string>
+     */
+    public static function middlewareAliases(): array
+    {
+        return [
+            'mcp.auth' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPAuthMiddleware::class,
+            'mcp.logging' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPLoggingMiddleware::class,
+            'mcp.security' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPSecurityMiddleware::class,
+            'mcp.throttle' => \ChaoticIngenuity\LaravelMCP\Http\Middleware\MCPThrottleMiddleware::class,
+        ];
+    }
 }


### PR DESCRIPTION
Summary of Changes:
fixed MCPServer.php line 44: 'tools' => new \stdClass() (was [])
added MCPServiceProvider::middlewareAliases() static helper
made logging middleware gracefully fall back to default channel
updated README with easier Laravel 11/12 setup
all 148 tests pass